### PR TITLE
fix: post-merge P2 findings — EINTR-safe threadSleep, runtime.deinit ownership

### DIFF
--- a/src/compat.zig
+++ b/src/compat.zig
@@ -200,11 +200,19 @@ pub fn nanoTimestamp() i128 {
 // keeps the old semantics bit-for-bit.
 
 pub fn threadSleep(nanoseconds: u64) void {
-    const ts = std.c.timespec{
+    var remaining = std.c.timespec{
         .sec = @intCast(nanoseconds / std.time.ns_per_s),
         .nsec = @intCast(nanoseconds % std.time.ns_per_s),
     };
-    _ = std.c.nanosleep(&ts, null);
+    // Loop across EINTR so signal delivery doesn't collapse the sleep —
+    // WAL and background workers rely on the full duration for backoff.
+    while (true) {
+        var rem: std.c.timespec = undefined;
+        const rc = std.c.nanosleep(&remaining, &rem);
+        if (rc == 0) return;
+        if (std.posix.errno(rc) != .INTR) return;
+        remaining = rem;
+    }
 }
 
 // ─── Random ───────────────────────────────────────────────────────────────

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -29,6 +29,9 @@ pub var io: std.Io = undefined;
 /// (which is published with a release store by the winner).
 const State = enum(u8) { uninit = 0, initing = 1, ready = 2 };
 var state: std.atomic.Value(u8) = std.atomic.Value(u8).init(@intFromEnum(State.uninit));
+/// True iff `init()` constructed `threaded` — `setIo()` and `ensureForTest()`
+/// publish externally-owned Io and must NOT tear down `threaded`.
+var owns_threaded: bool = false;
 
 /// Returns true if the caller won the CAS and should perform init; false if
 /// it lost or init already finished (in which case it has already spin-waited
@@ -54,6 +57,7 @@ pub fn init(gpa: std.mem.Allocator) void {
     if (!claimOrWait()) return;
     threaded = std.Io.Threaded.init(gpa, .{});
     io = threaded.io();
+    owns_threaded = true;
     state.store(@intFromEnum(State.ready), .release);
 }
 
@@ -64,12 +68,14 @@ pub fn init(gpa: std.mem.Allocator) void {
 pub fn setIo(external: std.Io) void {
     if (!claimOrWait()) return;
     io = external;
+    owns_threaded = false;
     state.store(@intFromEnum(State.ready), .release);
 }
 
 pub fn deinit() void {
     if (state.load(.acquire) != @intFromEnum(State.ready)) return;
-    threaded.deinit();
+    if (owns_threaded) threaded.deinit();
+    owns_threaded = false;
     state.store(@intFromEnum(State.uninit), .release);
 }
 
@@ -79,5 +85,6 @@ pub fn deinit() void {
 pub fn ensureForTest() void {
     if (!claimOrWait()) return;
     io = std.Io.Threaded.global_single_threaded.io();
+    owns_threaded = false;
     state.store(@intFromEnum(State.ready), .release);
 }


### PR DESCRIPTION
## Summary
Follow-up to [PR #125](https://github.com/justrach/turbodb/pull/125). Two P2 issues the Codex reviewer flagged after merge.

- **`compat.threadSleep`**: `nanosleep` now loops past EINTR, consuming the remaining-time out-param. A single signal could previously collapse a multi-second backoff to near-zero — WAL and background workers rely on the full duration for throttling.
- **`runtime.deinit`**: new `owns_threaded` flag; `deinit()` only calls `threaded.deinit()` when `init()` actually constructed it. `setIo()` and `ensureForTest()` publish externally-owned Io, and tearing down `threaded` on undefined state would be UB.

## Test plan
- [x] `zig build` clean (macOS)
- [ ] CI green on macos + ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)