### PR TITLE
[codex] Bound automatic text index growth

### DIFF
--- a/src/codeindex.zig
+++ b/src/codeindex.zig
@@ -17,6 +17,10 @@ pub const WordIndex = struct {
     file_words: std.StringHashMap(std.StringHashMap(void)),
     allocator: std.mem.Allocator,
 
+    /// Cap hits per word to bound memory. Common words add little search value
+    /// after this point and otherwise grow one hit per indexed document.
+    const MAX_HITS_PER_WORD: usize = 5_000;
+
     pub fn init(allocator: std.mem.Allocator) WordIndex {
         return .{
             .index = std.StringHashMap(std.ArrayList(WordHit)).init(allocator),
@@ -76,7 +80,6 @@ pub const WordIndex = struct {
         }
     }
 
-
     /// Index a file's content — tokenizes into words and records hits.
     pub fn indexFile(self: *WordIndex, path: []const u8, content: []const u8) !void {
         // Clean up old entries first
@@ -104,6 +107,8 @@ pub const WordIndex = struct {
                     gop.value_ptr.* = .empty;
                 }
 
+                if (gop.value_ptr.items.len >= MAX_HITS_PER_WORD) continue;
+
                 if (gop.value_ptr.items.len > 0) {
                     const last = gop.value_ptr.items[gop.value_ptr.items.len - 1];
                     if (std.mem.eql(u8, last.path, owned_path) and last.line_num == line_num) {
@@ -128,6 +133,12 @@ pub const WordIndex = struct {
             }
         }
 
+        if (words_set.count() == 0) {
+            words_set.deinit();
+            self.allocator.free(owned_path);
+            return;
+        }
+
         try self.file_words.put(owned_path, words_set);
     }
 
@@ -141,34 +152,52 @@ pub const WordIndex = struct {
 
     /// Look up hits, returning results allocated by the caller.
     /// Deduplicates by (path, line_num).
-pub fn searchDeduped(self: *WordIndex, word: []const u8, allocator: std.mem.Allocator) ![]const WordHit {
-    const hits = self.search(word);
-    if (hits.len == 0) return try allocator.alloc(WordHit, 0);
-    if (hits.len == 1) {
-        var out = try allocator.alloc(WordHit, 1);
-        out[0] = hits[0];
-        return out;
-    }
-
-    const DedupKey = struct { path_ptr: usize, line_num: u32 };
-    var seen = std.AutoHashMap(DedupKey, void).init(allocator);
-    defer seen.deinit();
-    try seen.ensureTotalCapacity(@intCast(hits.len));
-
-    var result: std.ArrayList(WordHit) = .empty;
-    errdefer result.deinit(allocator);
-    try result.ensureTotalCapacity(allocator, hits.len);
-
-    for (hits) |hit| {
-        const key = DedupKey{ .path_ptr = @intFromPtr(hit.path.ptr), .line_num = hit.line_num };
-        const gop = try seen.getOrPut(key);
-        if (!gop.found_existing) {
-            result.appendAssumeCapacity(hit);
+    pub fn searchDeduped(self: *WordIndex, word: []const u8, allocator: std.mem.Allocator) ![]const WordHit {
+        const hits = self.search(word);
+        if (hits.len == 0) return try allocator.alloc(WordHit, 0);
+        if (hits.len == 1) {
+            var out = try allocator.alloc(WordHit, 1);
+            out[0] = hits[0];
+            return out;
         }
+
+        const DedupKey = struct { path_ptr: usize, line_num: u32 };
+        var seen = std.AutoHashMap(DedupKey, void).init(allocator);
+        defer seen.deinit();
+        try seen.ensureTotalCapacity(@intCast(hits.len));
+
+        var result: std.ArrayList(WordHit) = .empty;
+        errdefer result.deinit(allocator);
+        try result.ensureTotalCapacity(allocator, hits.len);
+
+        for (hits) |hit| {
+            const key = DedupKey{ .path_ptr = @intFromPtr(hit.path.ptr), .line_num = hit.line_num };
+            const gop = try seen.getOrPut(key);
+            if (!gop.found_existing) {
+                result.appendAssumeCapacity(hit);
+            }
+        }
+        return result.toOwnedSlice(allocator);
     }
-    return result.toOwnedSlice(allocator);
-}
 };
+
+test "WordIndex skips empty per-file bookkeeping after hit cap" {
+    const alloc = std.testing.allocator;
+    var idx = WordIndex.init(alloc);
+    defer idx.deinit();
+
+    var saturated: std.ArrayList(WordHit) = .empty;
+    try saturated.ensureTotalCapacity(alloc, WordIndex.MAX_HITS_PER_WORD);
+    for (0..WordIndex.MAX_HITS_PER_WORD) |_| {
+        saturated.appendAssumeCapacity(.{ .path = "existing", .line_num = 1 });
+    }
+
+    const owned_word = try alloc.dupe(u8, "common");
+    try idx.index.put(owned_word, saturated);
+
+    try idx.indexFile("overflow", "common common common");
+    try std.testing.expectEqual(@as(usize, 0), idx.file_words.count());
+}
 
 // ── Trigram index ───────────────────────────────────────────
 // Maps 3-byte sequences → set of file paths.
@@ -180,7 +209,6 @@ pub const Trigram = u24;
 pub fn packTrigram(a: u8, b: u8, c: u8) Trigram {
     return @as(Trigram, a) << 16 | @as(Trigram, b) << 8 | @as(Trigram, c);
 }
-
 
 pub const PostingMask = struct {
     next_mask: u8 = 0, // bloom filter of chars following this trigram
@@ -250,7 +278,6 @@ fn postingSortedInsert(list: *PostingList, alloc: std.mem.Allocator, entry: Post
         list.append(alloc, entry) catch {};
     };
 }
-
 
 pub const TrigramIndex = struct {
     /// trigram → dense sorted posting list
@@ -464,119 +491,118 @@ pub const TrigramIndex = struct {
             self.file_trigrams.put(file_id, tri_list) catch {};
         }
     }
-pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.Allocator) ?[]const []const u8 {
-    self.mu.lockUncancelable(runtime.io);
-    defer self.mu.unlock(runtime.io);
+    pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.Allocator) ?[]const []const u8 {
+        self.mu.lockUncancelable(runtime.io);
+        defer self.mu.unlock(runtime.io);
 
-    if (query.len < 3) return null;
-    const tri_count = query.len - 2;
+        if (query.len < 3) return null;
+        const tri_count = query.len - 2;
 
-    // Deduplicate query trigrams first so repeated trigrams don't do repeated work.
-    var unique = std.AutoHashMap(Trigram, void).init(allocator);
-    defer unique.deinit();
-    unique.ensureTotalCapacity(@intCast(tri_count)) catch return null;
-    for (0..tri_count) |i| {
-        const tri = packTrigram(
-            normalizeChar(query[i]),
-            normalizeChar(query[i + 1]),
-            normalizeChar(query[i + 2]),
-        );
-        _ = unique.getOrPut(tri) catch return null;
-    }
+        // Deduplicate query trigrams first so repeated trigrams don't do repeated work.
+        var unique = std.AutoHashMap(Trigram, void).init(allocator);
+        defer unique.deinit();
+        unique.ensureTotalCapacity(@intCast(tri_count)) catch return null;
+        for (0..tri_count) |i| {
+            const tri = packTrigram(
+                normalizeChar(query[i]),
+                normalizeChar(query[i + 1]),
+                normalizeChar(query[i + 2]),
+            );
+            _ = unique.getOrPut(tri) catch return null;
+        }
 
-    var sets: std.ArrayList(*PostingList) = .empty;
-    defer sets.deinit(allocator);
-    sets.ensureTotalCapacity(allocator, unique.count()) catch return null;
+        var sets: std.ArrayList(*PostingList) = .empty;
+        defer sets.deinit(allocator);
+        sets.ensureTotalCapacity(allocator, unique.count()) catch return null;
 
-    var tri_iter = unique.keyIterator();
-    while (tri_iter.next()) |tri_ptr| {
-        const file_set = self.index.getPtr(tri_ptr.*) orelse {
+        var tri_iter = unique.keyIterator();
+        while (tri_iter.next()) |tri_ptr| {
+            const file_set = self.index.getPtr(tri_ptr.*) orelse {
+                return allocator.alloc([]const u8, 0) catch null;
+            };
+            sets.appendAssumeCapacity(file_set);
+        }
+
+        if (sets.items.len == 0) {
             return allocator.alloc([]const u8, 0) catch null;
+        }
+
+        // Iterate the smallest set and check membership in all others.
+        var min_idx: usize = 0;
+        var min_count = sets.items[0].items.len;
+        for (sets.items[1..], 1..) |set, i| {
+            const count = set.items.len;
+            if (count < min_count) {
+                min_count = count;
+                min_idx = i;
+            }
+        }
+
+        var result: std.ArrayList([]const u8) = .empty;
+        errdefer result.deinit(allocator);
+        result.ensureTotalCapacity(allocator, min_count) catch return null;
+
+        for (sets.items[min_idx].items) |entry| {
+            const file_id = entry.file_id;
+
+            // Intersection check: candidate must be in all sets
+            var in_all = true;
+            for (sets.items, 0..) |set, i| {
+                if (i == min_idx) continue;
+                if (!postingContains(set, file_id)) {
+                    in_all = false;
+                    break;
+                }
+            }
+            if (!in_all) continue;
+
+            // Bloom-filter check for consecutive trigram pairs
+            var bloom_pass = true;
+            if (tri_count >= 2) {
+                for (0..tri_count - 1) |j| {
+                    const tri_a = packTrigram(
+                        normalizeChar(query[j]),
+                        normalizeChar(query[j + 1]),
+                        normalizeChar(query[j + 2]),
+                    );
+                    const tri_b = packTrigram(
+                        normalizeChar(query[j + 1]),
+                        normalizeChar(query[j + 2]),
+                        normalizeChar(query[j + 3]),
+                    );
+                    const set_a = self.index.getPtr(tri_a) orelse continue;
+                    const set_b = self.index.getPtr(tri_b) orelse continue;
+                    const mask_a = postingGet(set_a, file_id) orelse continue;
+                    const mask_b = postingGet(set_b, file_id) orelse continue;
+
+                    // next_mask: bit for query[j+3] must be set in tri_a's next_mask
+                    const next_bit: u8 = @as(u8, 1) << @intCast(normalizeChar(query[j + 3]) % 8);
+                    if ((mask_a.next_mask & next_bit) == 0) {
+                        bloom_pass = false;
+                        break;
+                    }
+
+                    // loc_mask adjacency: use circular shift to handle position wrap-around
+                    const rotated = (mask_a.loc_mask << 1) | (mask_a.loc_mask >> 7);
+                    if ((rotated & mask_b.loc_mask) == 0) {
+                        bloom_pass = false;
+                        break;
+                    }
+                }
+            }
+            if (!bloom_pass) continue;
+
+            // Translate file_id -> path
+            if (file_id < self.id_to_path.items.len) {
+                result.appendAssumeCapacity(self.id_to_path.items[file_id]);
+            }
+        }
+
+        return result.toOwnedSlice(allocator) catch {
+            result.deinit(allocator);
+            return null;
         };
-        sets.appendAssumeCapacity(file_set);
     }
-
-    if (sets.items.len == 0) {
-        return allocator.alloc([]const u8, 0) catch null;
-    }
-
-    // Iterate the smallest set and check membership in all others.
-    var min_idx: usize = 0;
-    var min_count = sets.items[0].items.len;
-    for (sets.items[1..], 1..) |set, i| {
-        const count = set.items.len;
-        if (count < min_count) {
-            min_count = count;
-            min_idx = i;
-        }
-    }
-
-    var result: std.ArrayList([]const u8) = .empty;
-    errdefer result.deinit(allocator);
-    result.ensureTotalCapacity(allocator, min_count) catch return null;
-
-    for (sets.items[min_idx].items) |entry| {
-        const file_id = entry.file_id;
-
-        // Intersection check: candidate must be in all sets
-        var in_all = true;
-        for (sets.items, 0..) |set, i| {
-            if (i == min_idx) continue;
-            if (!postingContains(set, file_id)) {
-                in_all = false;
-                break;
-            }
-        }
-        if (!in_all) continue;
-
-        // Bloom-filter check for consecutive trigram pairs
-        var bloom_pass = true;
-        if (tri_count >= 2) {
-            for (0..tri_count - 1) |j| {
-                const tri_a = packTrigram(
-                    normalizeChar(query[j]),
-                    normalizeChar(query[j + 1]),
-                    normalizeChar(query[j + 2]),
-                );
-                const tri_b = packTrigram(
-                    normalizeChar(query[j + 1]),
-                    normalizeChar(query[j + 2]),
-                    normalizeChar(query[j + 3]),
-                );
-                const set_a = self.index.getPtr(tri_a) orelse continue;
-                const set_b = self.index.getPtr(tri_b) orelse continue;
-                const mask_a = postingGet(set_a, file_id) orelse continue;
-                const mask_b = postingGet(set_b, file_id) orelse continue;
-
-                // next_mask: bit for query[j+3] must be set in tri_a's next_mask
-                const next_bit: u8 = @as(u8, 1) << @intCast(normalizeChar(query[j + 3]) % 8);
-                if ((mask_a.next_mask & next_bit) == 0) {
-                    bloom_pass = false;
-                    break;
-                }
-
-                // loc_mask adjacency: use circular shift to handle position wrap-around
-                const rotated = (mask_a.loc_mask << 1) | (mask_a.loc_mask >> 7);
-                if ((rotated & mask_b.loc_mask) == 0) {
-                    bloom_pass = false;
-                    break;
-                }
-            }
-        }
-        if (!bloom_pass) continue;
-
-        // Translate file_id -> path
-        if (file_id < self.id_to_path.items.len) {
-            result.appendAssumeCapacity(self.id_to_path.items[file_id]);
-        }
-    }
-
-    return result.toOwnedSlice(allocator) catch {
-        result.deinit(allocator);
-        return null;
-    };
-}
-
 
     /// Find candidate files matching a RegexQuery.
     /// Intersects AND trigrams, then for each OR group unions posting lists
@@ -938,7 +964,10 @@ pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.All
                 if (result.file_trigrams.getPtr(file_id)) |tri_list| {
                     var found = false;
                     for (tri_list.items) |existing| {
-                        if (existing == tri) { found = true; break; }
+                        if (existing == tri) {
+                            found = true;
+                            break;
+                        }
                     }
                     if (!found) try tri_list.append(allocator, tri);
                 }
@@ -1006,9 +1035,7 @@ pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.All
         const header = try readDiskHeader(dir_path, allocator) orelse return null;
         return header.git_head;
     }
-
 };
-
 
 // ── Regex decomposition ─────────────────────────────────────
 
@@ -1046,11 +1073,30 @@ pub fn decomposeRegex(pattern: []const u8, allocator: std.mem.Allocator) !RegexQ
                 i += 2;
                 continue;
             }
-            if (c == '[') { in_bracket = true; i += 1; continue; }
-            if (c == ']') { in_bracket = false; i += 1; continue; }
-            if (in_bracket) { i += 1; continue; }
-            if (c == '(') { depth += 1; i += 1; continue; }
-            if (c == ')') { if (depth > 0) depth -= 1; i += 1; continue; }
+            if (c == '[') {
+                in_bracket = true;
+                i += 1;
+                continue;
+            }
+            if (c == ']') {
+                in_bracket = false;
+                i += 1;
+                continue;
+            }
+            if (in_bracket) {
+                i += 1;
+                continue;
+            }
+            if (c == '(') {
+                depth += 1;
+                i += 1;
+                continue;
+            }
+            if (c == ')') {
+                if (depth > 0) depth -= 1;
+                i += 1;
+                continue;
+            }
             if (c == '|' and depth == 0) {
                 try top_pipes.append(allocator, i);
             }
@@ -1243,7 +1289,6 @@ fn flushLiterals(
     literals.clearRetainingCapacity();
 }
 
-
 // ── Tokenizer ───────────────────────────────────────────────
 
 pub const WordTokenizer = struct {
@@ -1283,42 +1328,70 @@ pub const MAX_NGRAM_LEN: usize = 16;
 /// Rare pairs   → HIGH weight (they become n-gram boundaries).
 /// All unspecified pairs default to 0xFE00 (rare = high weight).
 pub const default_pair_freq: [256][256]u16 = blk: {
-
     var table: [256][256]u16 = .{.{0xFE00} ** 256} ** 256;
     // English bigrams (lowercase) — common in identifiers and prose
-    table['t']['h'] = 0x1000; table['h']['e'] = 0x1000;
-    table['i']['n'] = 0x1000; table['e']['r'] = 0x1000;
-    table['a']['n'] = 0x1000; table['r']['e'] = 0x1000;
-    table['o']['n'] = 0x1000; table['e']['n'] = 0x1000;
-    table['s']['t'] = 0x1000; table['e']['s'] = 0x1000;
-    table['a']['t'] = 0x1000; table['i']['o'] = 0x1000;
-    table['t']['e'] = 0x1000; table['o']['r'] = 0x1000;
-    table['t']['i'] = 0x1000; table['a']['r'] = 0x1000;
-    table['a']['l'] = 0x1000; table['l']['e'] = 0x1000;
-    table['n']['t'] = 0x1000; table['e']['d'] = 0x1000;
-    table['n']['d'] = 0x1000; table['o']['u'] = 0x1000;
-    table['e']['a'] = 0x1000; table['f']['o'] = 0x1000;
+    table['t']['h'] = 0x1000;
+    table['h']['e'] = 0x1000;
+    table['i']['n'] = 0x1000;
+    table['e']['r'] = 0x1000;
+    table['a']['n'] = 0x1000;
+    table['r']['e'] = 0x1000;
+    table['o']['n'] = 0x1000;
+    table['e']['n'] = 0x1000;
+    table['s']['t'] = 0x1000;
+    table['e']['s'] = 0x1000;
+    table['a']['t'] = 0x1000;
+    table['i']['o'] = 0x1000;
+    table['t']['e'] = 0x1000;
+    table['o']['r'] = 0x1000;
+    table['t']['i'] = 0x1000;
+    table['a']['r'] = 0x1000;
+    table['a']['l'] = 0x1000;
+    table['l']['e'] = 0x1000;
+    table['n']['t'] = 0x1000;
+    table['e']['d'] = 0x1000;
+    table['n']['d'] = 0x1000;
+    table['o']['u'] = 0x1000;
+    table['e']['a'] = 0x1000;
+    table['f']['o'] = 0x1000;
     // Common code keyword fragments
-    table['f']['n'] = 0x1000; table['i']['f'] = 0x1000;
-    table['r']['n'] = 0x1000; table['t']['u'] = 0x1000;
-    table['p']['u'] = 0x1000; table['b']['l'] = 0x1000;
-    table['c']['o'] = 0x1000; table['n']['s'] = 0x1000;
-    table['t']['r'] = 0x1000; table['u']['e'] = 0x1000;
+    table['f']['n'] = 0x1000;
+    table['i']['f'] = 0x1000;
+    table['r']['n'] = 0x1000;
+    table['t']['u'] = 0x1000;
+    table['p']['u'] = 0x1000;
+    table['b']['l'] = 0x1000;
+    table['c']['o'] = 0x1000;
+    table['n']['s'] = 0x1000;
+    table['t']['r'] = 0x1000;
+    table['u']['e'] = 0x1000;
     // Common operator / punctuation pairs
-    table['('][')'] = 0x0800; table['{']['}'] = 0x0800;
-    table['['][']'] = 0x0800; table['/']['/'] = 0x0800;
-    table['-']['>'] = 0x0800; table['=']['>'] = 0x0800;
-    table[':'][':'] = 0x0800; table['!']['='] = 0x0800;
-    table['=']['='] = 0x0800; table['<']['='] = 0x0800;
-    table['>']['='] = 0x0800; table['&']['&'] = 0x0800;
+    table['('][')'] = 0x0800;
+    table['{']['}'] = 0x0800;
+    table['['][']'] = 0x0800;
+    table['/']['/'] = 0x0800;
+    table['-']['>'] = 0x0800;
+    table['=']['>'] = 0x0800;
+    table[':'][':'] = 0x0800;
+    table['!']['='] = 0x0800;
+    table['=']['='] = 0x0800;
+    table['<']['='] = 0x0800;
+    table['>']['='] = 0x0800;
+    table['&']['&'] = 0x0800;
     table['|']['|'] = 0x0800;
     // Whitespace / structural pairs
-    table[' '][' '] = 0x0800; table['\t'][' '] = 0x0800;
-    table[' ']['('] = 0x0800; table[' ']['{'] = 0x0800;
-    table[';'][' '] = 0x0800; table[':'][' '] = 0x0800;
-    table['='][' '] = 0x0800; table[' ']['='] = 0x0800;
-    table[','][' '] = 0x0800; table['.']['.'] = 0x0800;
-    table['\n'][' '] = 0x0800; table['\n']['\t'] = 0x0800;
+    table[' '][' '] = 0x0800;
+    table['\t'][' '] = 0x0800;
+    table[' ']['('] = 0x0800;
+    table[' ']['{'] = 0x0800;
+    table[';'][' '] = 0x0800;
+    table[':'][' '] = 0x0800;
+    table['='][' '] = 0x0800;
+    table[' ']['='] = 0x0800;
+    table[','][' '] = 0x0800;
+    table['.']['.'] = 0x0800;
+    table['\n'][' '] = 0x0800;
+    table['\n']['\t'] = 0x0800;
     break :blk table;
 };
 
@@ -1326,7 +1399,6 @@ pub const default_pair_freq: [256][256]u16 = blk: {
 /// per-project table.  Swap only before indexing starts (not thread-safe).
 pub var active_pair_freq: *const [256][256]u16 = &default_pair_freq;
 var loaded_freq_table: [256][256]u16 = undefined;
-
 
 /// Deterministic weight for a character pair, used to place content-defined
 /// boundaries between n-grams.  Frequency-weighted: common source-code pairs
@@ -1464,7 +1536,7 @@ pub fn readFrequencyTable(dir_path: []const u8, allocator: std.mem.Allocator) !?
 
 /// A single sparse n-gram extracted from a string.
 pub const SparseNgram = struct {
-    hash: u64,  // Wyhash of the normalized (lowercased) n-gram bytes
+    hash: u64, // Wyhash of the normalized (lowercased) n-gram bytes
     pos: usize, // byte offset in the source string
     len: usize, // byte length of the n-gram
 };
@@ -1548,7 +1620,6 @@ pub fn extractSparseNgrams(content: []const u8, allocator: std.mem.Allocator) ![
                 // every byte in the span is covered.
                 try result.append(allocator, makeNgram(content, ngram_end - MIN_LEN, MIN_LEN));
             }
-
         }
     }
 

--- a/src/collection.zig
+++ b/src/collection.zig
@@ -1,13 +1,13 @@
 /// TurboDB — Collection (MVCC document store + query engine)
 const std = @import("std");
-const doc_mod   = @import("doc.zig");
-const page_mod  = @import("page.zig");
+const doc_mod = @import("doc.zig");
+const page_mod = @import("page.zig");
 const btree_mod = @import("btree.zig");
 const codeindex = @import("codeindex.zig");
-const wal_mod   = @import("wal");
+const wal_mod = @import("wal");
 const epoch_mod = @import("epoch");
 const hot_cache = @import("hot_cache.zig");
-const mvcc_mod  = @import("mvcc.zig");
+const mvcc_mod = @import("mvcc.zig");
 const cdc_mod = @import("cdc.zig");
 const vector = @import("vector.zig");
 const branch_mod = @import("branch.zig");
@@ -27,6 +27,18 @@ const WordIndex = codeindex.WordIndex;
 pub const DEFAULT_TENANT = "default";
 pub const MAX_TENANT_ID_LEN: usize = 64;
 pub const MAX_COLLECTION_NAME_LEN: usize = 64;
+const DEFAULT_TEXT_INDEX_MIN_VALUE_BYTES: usize = 128;
+
+fn envUsize(comptime name: [:0]const u8, default_value: usize) usize {
+    const raw_ptr = std.c.getenv(name.ptr) orelse return default_value;
+    const raw = std.mem.sliceTo(raw_ptr, 0);
+    if (raw.len == 0) return default_value;
+    return std.fmt.parseInt(usize, raw, 10) catch default_value;
+}
+
+fn textIndexMinValueBytes() usize {
+    return envUsize("TURBODB_TEXT_INDEX_MIN_VALUE_BYTES", DEFAULT_TEXT_INDEX_MIN_VALUE_BYTES);
+}
 
 // ─── IndexQueue ──────────────────────────────────────────────────────────
 // ─── IndexQueue ──────────────────────────────────────────────────────────
@@ -154,7 +166,10 @@ fn fastParseFloat(s: []const u8) ?f32 {
     if (s.len == 0) return null;
     var i: usize = 0;
     var neg: bool = false;
-    if (s[0] == '-') { neg = true; i = 1; }
+    if (s[0] == '-') {
+        neg = true;
+        i = 1;
+    }
     var int_part: i32 = 0;
     while (i < s.len and s[i] >= '0' and s[i] <= '9') : (i += 1) {
         int_part = int_part * 10 + @as(i32, s[i] - '0');
@@ -256,6 +271,7 @@ pub const Collection = struct {
     index_wake: std.atomic.Value(u32),
     queue_toggle: std.atomic.Value(u32),
     indexing_count: std.atomic.Value(u32),
+    text_index_min_value_bytes: usize,
 
     // Vector embedding column (optional)
     vectors: ?*vector.VectorColumn = null,
@@ -310,6 +326,7 @@ pub const Collection = struct {
         col.queue_toggle = std.atomic.Value(u32).init(0);
         col.indexing_count = std.atomic.Value(u32).init(0);
         col.index_wake = std.atomic.Value(u32).init(0);
+        col.text_index_min_value_bytes = textIndexMinValueBytes();
         col.vectors = null;
         col.vector_field_len = 0;
         col.vec_entries = .empty;
@@ -398,9 +415,9 @@ pub const Collection = struct {
         return self.name_buf[0..self.name_len];
     }
 
-    /// Return the number of live indexed documents (excludes deleted docs).
+    /// Return the number of live key entries (excludes deleted docs).
     pub fn docCount(self: *const Collection) u64 {
-        return @intCast(self.tri.fileCount());
+        return @intCast(self.hash_idx.count());
     }
 
     pub fn storageBytes(self: *const Collection) usize {
@@ -454,8 +471,8 @@ pub const Collection = struct {
         // Index the document.
         const entry = BTreeEntry{
             .key_hash = hdr.key_hash,
-            .doc_id   = doc_id,
-            .page_no  = pno,
+            .doc_id = doc_id,
+            .page_no = pno,
             .page_off = page_off,
         };
         try self.idx.insert(entry);
@@ -469,7 +486,7 @@ pub const Collection = struct {
         self.key_doc_ids.put(hdr.key_hash, doc_id) catch {};
 
         // Async trigram + word indexing — push to background queue, sync fallback if full or no worker.
-        if (value.len >= 3) {
+        if (self.shouldIndexText(value)) {
             if (self.index_thread == null) {
                 // No background worker — index synchronously to avoid losing data.
                 self.tri.indexFile(key, value) catch {};
@@ -521,7 +538,6 @@ pub const Collection = struct {
 
     /// Insert a document with a pre-computed embedding (no JSON parsing needed).
     /// This is the fast path — embedding is passed directly as f32 slice.
-
     /// Batch insert multiple (key, value) pairs. Each pair goes through the
     /// same single-insert path (no deeper internal batching yet — the primary
     /// win is amortizing FFI boundary crossings and syscall-style entry
@@ -660,8 +676,8 @@ pub const Collection = struct {
 
         const new_entry = BTreeEntry{
             .key_hash = key_hash,
-            .doc_id   = doc_id,
-            .page_no  = pno,
+            .doc_id = doc_id,
+            .page_no = pno,
             .page_off = page_off,
         };
         self.hash_idx.put(key_hash, new_entry) catch {};
@@ -745,7 +761,7 @@ pub const Collection = struct {
         const terms = terms_buf[0..term_count];
 
         // For single terms or exact phrase, try trigram index on full query first.
-        if (term_count == 1) {
+        if (term_count == 1 and self.hasCompleteTextIndex()) {
             const cand_paths = self.tri.candidates(query, alloc) orelse {
                 return self.bruteForceSearch(query, limit, alloc);
             };
@@ -772,6 +788,10 @@ pub const Collection = struct {
         var longest_idx: usize = 0;
         for (terms, 0..) |t, i| {
             if (t.len > terms[longest_idx].len) longest_idx = i;
+        }
+
+        if (!self.hasCompleteTextIndex()) {
+            return self.multiTermBruteForce(terms, limit, alloc);
         }
 
         const cand_paths = self.tri.candidates(terms[longest_idx], alloc) orelse {
@@ -837,7 +857,10 @@ pub const Collection = struct {
                 const nc = needle[j];
                 const hl = if (hc >= 'A' and hc <= 'Z') hc + 32 else hc;
                 const nl = if (nc >= 'A' and nc <= 'Z') nc + 32 else nc;
-                if (hl != nl) { match = false; break; }
+                if (hl != nl) {
+                    match = false;
+                    break;
+                }
             }
             if (match) return true;
         }
@@ -880,7 +903,9 @@ pub const Collection = struct {
     pub const ScanResult = struct {
         docs: []Doc,
         alloc: std.mem.Allocator,
-        pub fn deinit(self: ScanResult) void { self.alloc.free(self.docs); }
+        pub fn deinit(self: ScanResult) void {
+            self.alloc.free(self.docs);
+        }
     };
 
     /// Linear scan of all live documents, with optional limit/offset.
@@ -907,7 +932,10 @@ pub const Collection = struct {
                 const d = decoded.doc;
                 pos += decoded.consumed;
                 if (d.header.flags & DocHeader.DELETED != 0) continue;
-                if (skipped < offset) { skipped += 1; continue; }
+                if (skipped < offset) {
+                    skipped += 1;
+                    continue;
+                }
                 try results.append(alloc, d);
                 if (results.items.len >= limit) break :outer;
             }
@@ -958,8 +986,7 @@ pub const Collection = struct {
     }
 
     fn readEntry(self: *Collection, entry: BTreeEntry) ?Doc {
-        const raw = self.pf.leafRead(entry.page_no, entry.page_off,
-            DocHeader.size + 1024 + 65536);
+        const raw = self.pf.leafRead(entry.page_no, entry.page_off, DocHeader.size + 1024 + 65536);
         const decoded = doc_mod.decode(raw) catch return null;
         if (decoded.doc.header.flags & DocHeader.DELETED != 0) return null;
         return decoded.doc;
@@ -971,11 +998,23 @@ pub const Collection = struct {
         return @ptrCast(@alignCast(data[entry.page_off..].ptr));
     }
 
+    fn shouldIndexText(self: *const Collection, value: []const u8) bool {
+        return value.len >= 3 and value.len >= self.text_index_min_value_bytes;
+    }
+
+    fn hasCompleteTextIndex(self: *const Collection) bool {
+        const live_docs = self.hash_idx.count();
+        return live_docs > 0 and self.tri.fileCount() >= live_docs;
+    }
+
     fn findOrAllocLeaf(self: *Collection, needed: usize) !u32 {
         const total = self.pf.next_alloc.load(.acquire);
         var pno = if (total > 0) total - 1 else 0;
         var checked: u32 = 0;
-        while (checked < 32 and pno > 0) : ({ pno -= 1; checked += 1; }) {
+        while (checked < 32 and pno > 0) : ({
+            pno -= 1;
+            checked += 1;
+        }) {
             const ph = self.pf.pageHeader(pno);
             if (@as(page_mod.PageType, @enumFromInt(ph.page_type)) != .leaf) continue;
             if (page_mod.PAGE_USABLE - ph.used_bytes >= needed) return pno;
@@ -1005,7 +1044,7 @@ pub const Collection = struct {
                 if (d.header.flags & DocHeader.DELETED == 0) {
                     self.hash_idx.put(d.header.key_hash, entry) catch {};
                     self.key_doc_ids.put(d.header.key_hash, d.header.doc_id) catch {};
-                    if (d.value.len >= 3) {
+                    if (self.shouldIndexText(d.value)) {
                         self.tri.indexFile(d.key, d.value) catch {};
                         self.words.indexFile(d.key, d.value) catch {};
                     }
@@ -1424,9 +1463,9 @@ pub const Collection = struct {
                     var name_end = name_start;
                     while (name_end < doc.value.len and
                         ((doc.value[name_end] >= 'a' and doc.value[name_end] <= 'z') or
-                        (doc.value[name_end] >= 'A' and doc.value[name_end] <= 'Z') or
-                        (doc.value[name_end] >= '0' and doc.value[name_end] <= '9') or
-                        doc.value[name_end] == '_'))
+                            (doc.value[name_end] >= 'A' and doc.value[name_end] <= 'Z') or
+                            (doc.value[name_end] >= '0' and doc.value[name_end] <= '9') or
+                            doc.value[name_end] == '_'))
                     {
                         name_end += 1;
                     }
@@ -1520,6 +1559,11 @@ fn indexWorkerQ(col: *Collection, queue: *IndexQueue) void {
         var n: usize = 0;
         while (n < BATCH) {
             const popped = queue.pop() orelse break;
+            if (!col.shouldIndexText(popped.valueSlice())) {
+                var skipped = popped;
+                skipped.deinit(col.alloc);
+                continue;
+            }
             batch[n] = popped;
             batch_keys[n] = batch[n].keySlice();
             batch_vals[n] = batch[n].valueSlice();
@@ -1543,8 +1587,10 @@ fn indexWorkerQ(col: *Collection, queue: *IndexQueue) void {
     // Final drain on shutdown.
     while (queue.pop()) |popped| {
         var e = popped;
-        col.tri.indexFile(e.keySlice(), e.valueSlice()) catch {};
-        col.words.indexFile(e.keySlice(), e.valueSlice()) catch {};
+        if (col.shouldIndexText(e.valueSlice())) {
+            col.tri.indexFile(e.keySlice(), e.valueSlice()) catch {};
+            col.words.indexFile(e.keySlice(), e.valueSlice()) catch {};
+        }
         e.deinit(col.alloc);
     }
 }
@@ -2030,6 +2076,29 @@ test "tenant collections isolate keys and listings" {
     }
     try std.testing.expectEqual(@as(usize, 1), tenant_a_cols.items.len);
     try std.testing.expectEqualStrings("users", tenant_a_cols.items[0]);
+}
+
+test "small structured docs skip automatic text index and search falls back" {
+    const alloc = std.testing.allocator;
+    const tmp_dir = "/tmp/turbodb_small_doc_text_index_skip";
+    compat.fs.cwdDeleteTree(tmp_dir) catch {};
+    try compat.fs.cwdMakePath(tmp_dir);
+    defer compat.fs.cwdDeleteTree(tmp_dir) catch {};
+
+    const db = try Database.open(alloc, tmp_dir);
+    defer db.close();
+
+    const col = try db.collection("events");
+    _ = try col.insert("small", "{\"kind\":\"tiny\"}");
+    _ = try col.insert("large", "{\"body\":\"needle abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789\"}");
+    col.flushIndex();
+
+    try std.testing.expectEqual(@as(u32, 1), col.tri.fileCount());
+
+    const result = try col.searchText("tiny", 10, alloc);
+    defer result.deinit();
+    try std.testing.expectEqual(@as(usize, 1), result.docs.len);
+    try std.testing.expectEqualStrings("small", result.docs[0].key);
 }
 
 test "tenant quotas apply per tenant" {


### PR DESCRIPTION
## Summary
- bound automatic text indexing to larger document values by default (`TURBODB_TEXT_INDEX_MIN_VALUE_BYTES`, default 128 bytes)
- make collection doc counts use live key entries instead of trigram-indexed files
- fall back to brute-force search when the text index is intentionally partial
- cap high-frequency WordIndex postings and avoid empty per-file bookkeeping after the cap is hit

## Validation
- `zig build -Doptimize=ReleaseSafe`
- `zig build -Dtarget=aarch64-linux-musl -Doptimize=ReleaseFast`
- `zig build test`
- `zig test --dep compat --dep runtime -Mroot=src/codeindex.zig -Mcompat=src/compat.zig -Mruntime=src/runtime.zig -lc`
- `git diff --check`

Note: direct `src/collection.zig` test execution is currently blocked on `main` by unrelated Zig 0.16 compile errors in `src/cdc.zig` (`std.Thread.sleep` removal), before this patch's collection test can run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/turbodb/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
